### PR TITLE
Fixes to resource ui schema

### DIFF
--- a/src/state/ducks/scidata/schema/resource.json
+++ b/src/state/ducks/scidata/schema/resource.json
@@ -8,8 +8,8 @@
       "type": "object",
       "properties": {
         "@id": { "type": "string" },
-        "name": { "type": "string" },
         "type": { "type": "string" },
+        "name": { "type": "string" },
         "vendor": { "type": "string" },
         "catalognumber": { "type": "string" },
         "origin": { "type": "string" }

--- a/src/state/ducks/scidata/uischema/index.tsx
+++ b/src/state/ducks/scidata/uischema/index.tsx
@@ -1,4 +1,5 @@
 import datasetUiSchema from './dataset.json';
+import resourceUiSchema from './resource.json';
 import parameterUiSchema from './parameter.json';
 import unitUiSchema from './unit.json';
 import valueUiSchema from './value.json';
@@ -7,6 +8,7 @@ import valueUiSchema from './value.json';
 const uischemas = {
     dataset: datasetUiSchema,
     parameter: parameterUiSchema,
+    resource: resourceUiSchema,
     unit: unitUiSchema,
     value: valueUiSchema,
 }

--- a/src/state/ducks/scidata/uischema/resource.json
+++ b/src/state/ducks/scidata/uischema/resource.json
@@ -18,6 +18,11 @@
     },
     {
       "type": "Control",
+      "label": "Name of Resource",
+      "scope": "#/properties/name"
+    },
+    {
+      "type": "Control",
       "label": "Vendor of Resource",
       "scope": "#/properties/vendor"
     },
@@ -25,6 +30,16 @@
       "type": "Control",
       "label": "Catalog Number of Resource",
       "scope": "#/properties/catalognumber"
+    },
+    {
+      "type": "Control",
+      "label": "Origin of Resource",
+      "scope": "#/properties/resourceOrigin"
+    },
+    {
+      "type": "Control",
+      "label": "Resource Object",
+      "scope": "#/properties/resource"
     }
   ]
 }


### PR DESCRIPTION
The `resource` uischema was not added to index so default ui was being generated. This switches to the uischema in the project and adds fixes to that schema