### PR TITLE
Bug fix in parameter scope property

### DIFF
--- a/src/state/ducks/scidata/schema/parameter.json
+++ b/src/state/ducks/scidata/schema/parameter.json
@@ -9,7 +9,7 @@
       "properties": {
         "@id": { "type": "string" },
         "name": { "type": "string" },
-        "scope": { "$ref": "string" },
+        "scope": { "type": "string" },
         "source": { "type": "string" },
         "quantity": { "type": "string" },
         "quantityref": { "type": "string" },


### PR DESCRIPTION
Had `$ref` instead of `type`. Causing issues in putting together `methodology` schema.