### PR TITLE
Methodology schema + cleanup

### DIFF
--- a/src/state/ducks/scidata/constants/schemaList.js
+++ b/src/state/ducks/scidata/constants/schemaList.js
@@ -1,6 +1,7 @@
 export default [
     'dataset',
     'measurement',
+    'methodology',
     'parameter',
     'resource',
     'unit', 

--- a/src/state/ducks/scidata/schema/index.tsx
+++ b/src/state/ducks/scidata/schema/index.tsx
@@ -1,6 +1,7 @@
 import contextSchema from './context.json';
 import datasetSchema from './dataset.json';
 import measurementSchema from './measurement.json';
+import methodologySchema from './methodology.json';
 import parameterSchema from './parameter.json';
 import resourceSchema from './resource.json';
 import unitSchema from './unit.json';
@@ -10,6 +11,7 @@ const schemas = {
     context: contextSchema,
     dataset: datasetSchema,
     measurement: measurementSchema,
+    methodology: methodologySchema,
     parameter: parameterSchema,
     resource: resourceSchema,
     unit: unitSchema,

--- a/src/state/ducks/scidata/schema/measurement.json
+++ b/src/state/ducks/scidata/schema/measurement.json
@@ -16,7 +16,6 @@
         "settings": {
           "type": "array",
           "items": { "$ref": "parameter.json#/properties/parameter" }
-          }
         }
       }
     }

--- a/src/state/ducks/scidata/schema/measurement.json
+++ b/src/state/ducks/scidata/schema/measurement.json
@@ -16,6 +16,7 @@
         "settings": {
           "type": "array",
           "items": { "$ref": "parameter.json#/properties/parameter" }
+          }
         }
       }
     }
@@ -36,6 +37,7 @@
     "settings": {
       "type": "array",
       "items": { "$ref": "parameter.json#/properties/parameter" }
-    }
+    },
+    "measurement": { "$ref": "#/definitions/measurement_def" }
   }
 }

--- a/src/state/ducks/scidata/schema/methodology.json
+++ b/src/state/ducks/scidata/schema/methodology.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Methodology Schema",
+  "description": "JSON schema for methodology",
+  "type": "object",
+  "definitions": {
+    "evaluation_def": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["experimental", "calculation", "extracted"]
+      }
+    },
+    "aspects_def": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          { "$ref": "measurement.json#/properties/measurement" },
+          { "$ref": "resource.json#/properties/resource" }
+        ]
+      }
+    },
+    "methodology_def": {
+      "type": "object",
+      "properties": {
+        "@id": { "type": "string" },
+        "evaluation": { "$ref": "#/definitions/evaluation_def" },
+        "aspects": {"$ref": "#/definitions/aspects_def"}
+      }
+    }
+  },
+  "properties": {
+    "@context": {
+      "$ref": "context.json#/@context",
+      "default": [
+        "http://stuchalk.github.io/scidata/contexts/scidata_measurement.jsonld"
+      ]
+    },
+    "@id": { "type": "string" },
+    "@type": { "type": "string" },
+    "methodology": { "$ref": "#/definitions/methodology_def" },
+    "evaluation": { "$ref": "#/definitions/evaluation_def" },
+    "aspects": { "$ref": "#/definitions/aspects_def" }
+  }
+}

--- a/src/state/ducks/scidata/uischema/index.tsx
+++ b/src/state/ducks/scidata/uischema/index.tsx
@@ -1,5 +1,6 @@
 import datasetUiSchema from './dataset.json';
 import measurementUiSchema from './measurement.json';
+import methodologyUiSchema from './methodology.json';
 import parameterUiSchema from './parameter.json';
 import resourceUiSchema from './resource.json';
 import unitUiSchema from './unit.json';
@@ -9,6 +10,7 @@ import valueUiSchema from './value.json';
 const uischemas = {
     dataset: datasetUiSchema,
     measurement: measurementUiSchema,
+    methodology: methodologyUiSchema,
     parameter: parameterUiSchema,
     resource: resourceUiSchema,
     unit: unitUiSchema,

--- a/src/state/ducks/scidata/uischema/methodology.json
+++ b/src/state/ducks/scidata/uischema/methodology.json
@@ -1,0 +1,30 @@
+{
+  "type": "VerticalLayout",
+  "elements": [
+    {
+      "type": "Control",
+      "label": "JSON-LD Contexts",
+      "scope": "#/properties/@context"
+    },
+    {
+      "type": "Control",
+      "label": "ID for Methodology",
+      "scope": "#/properties/@id"
+    },
+    {
+      "type": "Control",
+      "label": "Type for Methodology",
+      "scope": "#/properties/@type"
+    },
+    {
+      "type": "Control",
+      "label": "Evaulation Type for Methodology",
+      "scope": "#/properties/evaluation"
+    },
+    {
+      "type": "Control",
+      "label": "Aspects of Methodology",
+      "scope": "#/properties/aspects"
+    }
+  ]
+}

--- a/src/state/ducks/scidata/uischema/resource.json
+++ b/src/state/ducks/scidata/uischema/resource.json
@@ -35,11 +35,6 @@
       "type": "Control",
       "label": "Origin of Resource",
       "scope": "#/properties/resourceOrigin"
-    },
-    {
-      "type": "Control",
-      "label": "Resource Object",
-      "scope": "#/properties/resource"
     }
   ]
 }


### PR DESCRIPTION
 - Adds `methodology` partial schema (only `resource` and `measurement` included)
 - Removes `resource` property display in `resource` UI schema
 - Adds missing `measurement` property for `measurement` schema